### PR TITLE
Use the same shell for :ruby_subprocess_cmd

### DIFF
--- a/bench_lib.rb
+++ b/bench_lib.rb
@@ -28,7 +28,8 @@ module BenchLib
 
       # Runner Config
       before_worker_cmd: "bundle install",
-      ruby_subprocess_cmd: "bash -l -c \"BEFORE_WORKER && ruby SUBPROCESS_SCRIPT JSON_FILENAME\"",
+      ruby_subprocess_cmd: "BEFORE_WORKER && ruby SUBPROCESS_SCRIPT JSON_FILENAME",
+      wrap_subprocess_cmd: "COMMAND",
       json_filename: "/tmp/benchlib_#{Process.pid}.json",
       wrk_subprocess: File.expand_path(File.join(__dir__, "wrk_subprocess.rb")),
 
@@ -242,6 +243,8 @@ module BenchLib
         @settings[opt].gsub! "JSON_FILENAME", @settings[:json_filename]
         @settings[opt].gsub! "SUBPROCESS_SCRIPT", @settings[:wrk_subprocess]
       end
+
+      @settings[:ruby_subprocess_cmd] = @settings[:wrap_subprocess_cmd].sub('COMMAND', @settings[:ruby_subprocess_cmd])
     end
 
     # Output files are particularly liable to have TIMESTAMP substituted in

--- a/runners/rvm_batching.rb
+++ b/runners/rvm_batching.rb
@@ -301,7 +301,7 @@ def run_benchmark(orig_opts)
 
     :verbose => 1,
 
-    before_worker_cmd: "rvm use #{orig_opts[:ruby]} && #{SETTINGS_DEFAULTS[:before_worker_cmd]}",  # Run before each batch
+    wrap_subprocess_cmd: "bash -l -c \"rvm use #{orig_opts[:ruby]} && COMMAND\"",
     bundle_gemfile: bundle_gemfile,
     rack_env: orig_opts[:rack_env],
 

--- a/runners/rvm_rubies.rb
+++ b/runners/rvm_rubies.rb
@@ -119,7 +119,7 @@ def run_benchmark(rvm_ruby_version, rack_or_rails, run_index)
 
     :verbose => 1,
 
-    before_worker_cmd: "rvm use #{rvm_ruby_version} && #{SETTINGS_DEFAULTS[:before_worker_cmd]}",  # Run before each batch
+    wrap_subprocess_cmd: "bash -l -c \"rvm use #{rvm_ruby_version} && COMMAND\"",
     bundle_gemfile: "Gemfile.#{rvm_ruby_version}",
 
     # Useful for debugging, annoying for day-to-day use


### PR DESCRIPTION
* For instance, I use ZSH and this would shell out to Bash which uses a completely different config.
* `-l` is also harmful in that it resets the PATH instead of inheriting from the parent process.