### PR TITLE
Dynamic Gemfile fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,6 @@ script:
   - runners/current_ruby_cli.rb -h
   - runners/current_ruby_cli.rb --benchmark-seconds 5 rack webrick
   - runners/current_ruby_cli.rb --benchmark-seconds 5 rails webrick
+  - runners/current_ruby_cli.rb --benchmark-seconds 5 rack puma
+  - runners/current_ruby_cli.rb --benchmark-seconds 5 rails puma
   - ./process.rb -c RUBY_DESCRIPTION,server_cmd,timestamp -i 'data/rsb_*.json'

--- a/bench_lib.rb
+++ b/bench_lib.rb
@@ -431,11 +431,12 @@ module BenchLib
       send(method_name, processes: processes, threads: threads)
     end
 
-    # This generates a temporary configuration file, using the Tmpfile API, which can
+    # This generates a temporary configuration file, using the Tempfile API, which can
     # be used for an application server like Unicorn that may require its configuration
     # be from a file.
     def temp_config_file(contents)
-      t = Tmpfile.new("RSB_config_#{Process.pid}_")
+      require 'tempfile'
+      t = Tempfile.new("RSB_config_#{Process.pid}_")
       t.to_s
     end
 

--- a/bench_lib.rb
+++ b/bench_lib.rb
@@ -731,6 +731,31 @@ UNICORN_CONFIG
     # This list is a bit optimistic
     RUBY_TYPES = [ :cruby, :jruby, :truffleruby ]
 
+    def setup_gemfile(ruby_version, app, opts)
+      bench_dir = "#{app}_test_app"
+      extra_gems = opts.delete(:extra_gems) || []
+
+      case opts[:bundle_gemfile]
+      when nil, "dynamic", "Gemfile.dynamic"
+        # Write out Gemfile.dynamic and Gemfile.dynamic.lock
+        File.open("#{bench_dir}/Gemfile.dynamic", "w") do |f|
+          f.write(gemfile_contents(ruby_version, :cruby, app, extra_gems))
+        end
+        File.open("#{bench_dir}/Gemfile.dynamic.lock", "w") do |f|
+          f.write(gemfile_lock_contents(ruby_version, :cruby, app, extra_gems))
+        end
+        opts[:bundle_gemfile] = "Gemfile.dynamic"
+      when String
+        bundle_gemfile = "#{bench_dir}/#{opts[:bundle_gemfile]}"
+        unless File.exist?(bundle_gemfile)
+          raise "Supplied Gemfile path does not exist for this framework: #{bundle_gemfile.inspect}!"
+        end
+        opts[:bundle_gemfile] = bundle_gemfile
+      else
+        raise "Unrecognized value for :bundle_gemfile option: #{opts[:bundle_gemfile].inspect}!"
+      end
+    end
+
     def gemfile_contents(ruby_version, ruby_type, framework, extras)
       send("#{ruby_type}_#{framework}_gemfile_contents", ruby_version, extras)
     end

--- a/runners/current_ruby.rb
+++ b/runners/current_ruby.rb
@@ -36,20 +36,7 @@ bench_dir = "#{which_app}_test_app"
 
 # Default concurrency
 rr_opts = options_by_framework_and_server(which_app, server).merge(opts)
-extra_gems = rr_opts.delete(:extra_gems) || []
-
-# Dynamic gemfile generation
-if opts[:bundle_gemfile].nil? || opts[:bundle_gemfile] == "Gemfile.dynamic"
-  File.open("#{bench_dir}/Gemfile.dynamic", "w") do |f|
-    f.write(gemfile_contents(ruby_version, :cruby, which_app, extra_gems))
-  end
-  File.open("#{bench_dir}/Gemfile.dynamic.lock", "w") do |f|
-    f.write(gemfile_lock_contents(ruby_version, :cruby, which_app, extra_gems))
-  end
-  rr_opts[:bundle_gemfile] = "Gemfile.dynamic" # Have to be able to find Gemfile.dynamic.lock
-else
-  rr_opts[:bundle_gemfile] = "#{bench_dir}/#{opts[:bundle_gemfile]}"
-end
+setup_gemfile(ruby_version, which_app, rr_opts)
 
 # Finally, run the benchmark
 Dir.chdir(bench_dir) do

--- a/runners/current_ruby_cli.rb
+++ b/runners/current_ruby_cli.rb
@@ -8,11 +8,11 @@ require 'optparse'
 require_relative "../bench_lib"
 include BenchLib
 include BenchLib::OptionsBuilder
+include BenchLib::GemfileGenerator
 
 overrides = {
   wrk_close_connection: true,
   url: "http://127.0.0.1:PORT/static",
-  bundle_gemfile: "Gemfile.#{RUBY_VERSION}",
   suppress_server_output: false,
 }
 defaults = BenchLib::SETTINGS_DEFAULTS.merge(overrides)
@@ -54,7 +54,7 @@ p options
 
 # Default concurrency
 options = options_by_framework_and_server(which_app, server).merge(options)
-extra_gems = options.delete(:extra_gems) || [] # Can be used for dynamic Gemfile generation
+setup_gemfile(RUBY_VERSION, which_app, options)
 
 # Here's the meat of how to turn those options into benchmark output
 Dir.chdir("#{which_app}_test_app") do


### PR DESCRIPTION
This lets the dynamic Gemfile works for the `current_ruby_cli.rb` runner too, and shares the logic between all 3 runners.