### PR TITLE
Fixes a NoMethodError on ./runners/current_ruby.rb

### DIFF
--- a/bench_lib.rb
+++ b/bench_lib.rb
@@ -12,6 +12,7 @@
 require "json"
 require "bundler"
 require "timeout"
+require "uri"
 
 module BenchLib
 


### PR DESCRIPTION
I got this error while running `./runners/current_ruby.rb` and this commit fixes it:

```
Running command: wrk -t1 -c10 -d20s -s/Users/yuki/GitHub/rsb/./final_report.lua --header "Connection: Close" --latency http://127.0.0.1:4321/static
Traceback (most recent call last):
	3: from /Users/yuki/GitHub/rsb/wrk_subprocess.rb:12:in `<main>'
	2: from /Users/yuki/GitHub/rsb/bench_lib.rb:377:in `subprocess_main'
	1: from /Users/yuki/GitHub/rsb/bench_lib.rb:198:in `with_url_available'
/Users/yuki/GitHub/rsb/bench_lib.rb:400:in `block in subprocess_main': undefined method `URI' for #<BenchLib::BenchmarkEnvironment:0x00007fa207950d20> (NoMethodError)
```

And the Ruby version is:

```
ruby 2.7.0dev (2019-12-25T09:47:47Z master e1e1d92277) [x86_64-darwin18]
```