### PR TITLE
Make error message for wrk more helpful

### DIFF
--- a/bench_lib.rb
+++ b/bench_lib.rb
@@ -230,7 +230,13 @@ module BenchLib
       if @settings[:wrk_binary] == "wrk"
         which_wrk = `which wrk`
         unless which_wrk && which_wrk.strip != ""
-          raise "No wrk binary in path! Build or install the binary and/or specify a path!"
+          raise "No wrk binary in path! Build or install the binary and/or specify a path!" \
+                "\n\n" \
+                "  To install wrk please refer to the official documentation:\n" \
+                "\n" \
+                "    * Linux: https://github.com/wg/wrk/wiki/Installing-Wrk-on-Linux\n" \
+                "    * OS X: https://github.com/wg/wrk/wiki/Installing-wrk-on-OS-X\n" \
+                "\n"
         end
       end
 


### PR DESCRIPTION
I didn't know about `wrk` and it would have been great if the error message told me what to do to install it, so here comes a pull request. The error message will look like this:

<img width="1473" alt="Screen Shot 2019-12-25 at 17 05 12" src="https://user-images.githubusercontent.com/386234/71450898-d72e2980-2738-11ea-9ad6-60230eb78aaa.png">
